### PR TITLE
Friendly behavior when the user never owned the item

### DIFF
--- a/client/vdkinv.lua
+++ b/client/vdkinv.lua
@@ -176,7 +176,7 @@ end
 ------------------------- EXPORTS METHODS -------------------------
 
 function getQuantity(itemId)
-    return ITEMS[tonumber(itemId)].quantity
+    return ITEMS[tonumber(itemId)].quantity or 0
 end
 
 function getPods()


### PR DESCRIPTION
EN:
Friendly behavior when the user never owned the specified item, it will return `0` instead of `nil`.

FR:
Si l'utilisateur n'a jamais été en possession de l'item alors cela ne retournera pas `nil` mais `0`.
C'est plus logique comme comportement.